### PR TITLE
💬 update `opticrd` reference to `ogticrd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Proporciona una manera sencilla de indentificar que se está navegando en una we
 Para integrar esta herramienta en un proyecto, copie el siguiente código y coloquelo en el archivo del index.html de su proyecto.
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/opticrd/official-header/main.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/ogticrd/official-header/main.js" defer></script>
 ```
 
 En caso de desear utilizar el tema dark, basta con cambiar la importación del script por:
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/gh/opticrd/official-header/main.js"
+  src="https://cdn.jsdelivr.net/gh/ogticrd/official-header/main.js"
   defer
   theme="dark"
 ></script>

--- a/main.js
+++ b/main.js
@@ -192,7 +192,7 @@ class GovernmentOfficialHeader extends HTMLElement {
     <div class="official-header ${theme}">
      <div class="row container">
        <div>
-         <img class="flag" src="https://raw.githubusercontent.com/opticrd/official-header/master/assets/icons/dominican-flag.svg" alt="Dominican flag">
+         <img class="flag" src="https://raw.githubusercontent.com/ogticrd/official-header/master/assets/icons/dominican-flag.svg" alt="Dominican flag">
          <p>Esta es una web oficial del Gobierno de la República Dominicana</p>
         </div>
          
@@ -211,7 +211,7 @@ class GovernmentOfficialHeader extends HTMLElement {
 
       <div>
           <span class="icon">
-            <img src="https://raw.githubusercontent.com/opticrd/official-header/master/assets/icons/cupula.svg" alt="cupula">
+            <img src="https://raw.githubusercontent.com/ogticrd/official-header/master/assets/icons/cupula.svg" alt="cupula">
           </span>
           <div>
             <p class="subtitle">Los sitios web oficiales utilizan .gob.do, .gov.do o .mil.do</p>
@@ -221,7 +221,7 @@ class GovernmentOfficialHeader extends HTMLElement {
       
       <div>
           <span class="icon">
-            <img src="https://raw.githubusercontent.com/opticrd/official-header/master/assets/icons/lock.svg" alt="cupula">
+            <img src="https://raw.githubusercontent.com/ogticrd/official-header/master/assets/icons/lock.svg" alt="cupula">
           </span>
           <div>
             <p class="subtitle">Los sitios web oficiales .gob.do, .gov.do o .mil.do seguros usan HTTPS</p>


### PR DESCRIPTION
Hola, ya que el nombre de la Organización cambió de `opticrd` a `ogticrd`, sería bueno hacer el cambio en la referencia de las URLs de los assets, de esa forma, se evita que no sean encontrados en el futuro.

Creo que es importante tambien avisar antes de hacer el cambio (hacer merge de este PR).