### PR TITLE
Obteniendo el tag con GetElementById en vez de current script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,18 @@ Proporciona una manera sencilla de indentificar que se está navegando en una we
 Para integrar esta herramienta en un proyecto, copie el siguiente código y coloquelo en el archivo del index.html de su proyecto.
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/ogticrd/official-header/main.js" defer></script>
+<script
+  id="official-header"
+  src="https://cdn.jsdelivr.net/gh/ogticrd/official-header/main.js"
+  defer
+></script>
 ```
 
 En caso de desear utilizar el tema dark, basta con cambiar la importación del script por:
 
 ```html
 <script
+  id="official-header"
   src="https://cdn.jsdelivr.net/gh/ogticrd/official-header/main.js"
   defer
   theme="dark"

--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 class GovernmentOfficialHeader extends HTMLElement {
   constructor() {
     const theme =
-      (document.currentScript &&
-        document.currentScript.getAttribute("theme")) ||
+      (document.getElementById("official-header") &&
+        document.getElementById("official-header").getAttribute("theme")) ||
       "light";
     super();
     const template = document.createElement("template");


### PR DESCRIPTION
En algunos casos, la web no carga las propiedades (como theme) porque document.currentScript es nulo.
![image](https://github.com/ogticrd/official-header/assets/8787121/6701df9e-afd2-4347-8b00-d184674e09ed)

Lo que hice fue, cambiar el document.currentScript por un document.getElementById y asignarle el id tambien al tag de script. 

Tambien fue actualizada la documentacion para aplicar los cambios necesarios.